### PR TITLE
Fix/repay logic

### DIFF
--- a/apis/market.ts
+++ b/apis/market.ts
@@ -88,7 +88,7 @@ export async function fetchDepositApyByEpochsDeposited(
   return markets
     .map((_, i) => markets.slice(0, i + 1))
     .map((markets) => {
-      const { apy, proceeds, available } = calculateDepositApy(
+      const { apy, proceeds } = calculateDepositApy(
         substitute,
         markets,
         amount,
@@ -101,7 +101,6 @@ export async function fetchDepositApyByEpochsDeposited(
           .replace(/-/g, '/'), // TODO: format properly
         proceeds,
         apy,
-        available,
       }
     })
 }

--- a/components/modal/borrow-more-modal.tsx
+++ b/components/modal/borrow-more-modal.tsx
@@ -5,6 +5,7 @@ import { LoanPosition } from '../../model/loan-position'
 import CurrencyAmountInput from '../currency-amount-input'
 import { Arrow } from '../svg/arrow'
 import { Prices } from '../../model/prices'
+import { min } from '../../utils/bigint'
 
 import Modal from './modal'
 
@@ -54,7 +55,7 @@ const BorrowMoreModal = ({
           value={currencyInputValue}
           onValueChange={setCurrencyInputValue}
           price={prices[position.underlying.address]}
-          balance={maxLoanableAmount}
+          balance={min(maxLoanableAmount, available)}
         />
       </div>
       <div className="flex flex-col mb-6 sm:mb-8 gap-2 sm:gap-3 text-xs sm:text-sm">

--- a/components/modal/borrow-more-modal.tsx
+++ b/components/modal/borrow-more-modal.tsx
@@ -55,7 +55,7 @@ const BorrowMoreModal = ({
           value={currencyInputValue}
           onValueChange={setCurrencyInputValue}
           price={prices[position.underlying.address]}
-          balance={min(maxLoanableAmount, available)}
+          balance={min(maxLoanableAmount - maxInterest, available)}
         />
       </div>
       <div className="flex flex-col mb-6 sm:mb-8 gap-2 sm:gap-3 text-xs sm:text-sm">

--- a/components/modal/repay-modal.stories.tsx
+++ b/components/modal/repay-modal.stories.tsx
@@ -32,7 +32,6 @@ export const Default: Story = {
       },
     },
     repayAmount: dummyLoanPosition.amount,
-    available: 10n,
     balances: {
       '0x82af49447d8a07e3bd95bd0d56f35241523fbab1': 10n,
     },
@@ -47,7 +46,6 @@ export const Default: Story = {
     repay: async () => {},
     amount: dummyLoanPosition.amount,
     refund: 0n,
-    minBalance: dummyLoanPosition.amount,
   },
 }
 

--- a/components/modal/repay-modal.tsx
+++ b/components/modal/repay-modal.tsx
@@ -33,6 +33,7 @@ const RepayModal = ({
   repayWithCollateral,
   repay,
   amount,
+  maxRefund,
   refund,
 }: {
   onClose: () => void
@@ -65,6 +66,7 @@ const RepayModal = ({
     expectedProceeds: bigint,
   ) => Promise<void>
   amount: bigint
+  maxRefund: bigint
   refund: bigint
 }) => {
   return (
@@ -125,7 +127,7 @@ const RepayModal = ({
               onValueChange={setValue}
               price={prices[position.underlying.address]}
               balance={min(
-                position.amount,
+                position.amount - maxRefund,
                 balances[position.underlying.address],
               )}
             />

--- a/components/modal/repay-modal.tsx
+++ b/components/modal/repay-modal.tsx
@@ -196,7 +196,7 @@ const RepayModal = ({
           repayAmount === 0n ||
           (!isUseCollateral &&
             repayAmount > balances[position.underlying.address]) ||
-          (!isUseCollateral && repayAmount > position.amount - maxRefund)
+          repayAmount > position.amount - maxRefund
         }
         className="font-bold text-base sm:text-xl bg-green-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 h-12 sm:h-16 rounded-lg text-white disabled:text-gray-300 dark:disabled:text-gray-500"
         onClick={async () => {
@@ -230,7 +230,7 @@ const RepayModal = ({
           : !isUseCollateral &&
             repayAmount > balances[position.underlying.address]
           ? `Insufficient ${position.underlying.symbol} balance`
-          : !isUseCollateral && repayAmount > position.amount - maxRefund
+          : repayAmount > position.amount - maxRefund
           ? `Cannot repay more than remaining debt`
           : isUseCollateral
           ? 'Repay with Collateral'

--- a/components/modal/repay-modal.tsx
+++ b/components/modal/repay-modal.tsx
@@ -153,7 +153,7 @@ const RepayModal = ({
           <div className="flex items-center gap-1">
             <span>
               {formatUnits(
-                position.amount,
+                position.amount - maxRefund,
                 position.underlying.decimals,
                 prices[position.underlying.address],
               )}{' '}
@@ -164,7 +164,7 @@ const RepayModal = ({
                 <Arrow />
                 <span className="text-green-500">
                   {formatUnits(
-                    position.amount - repayAmount,
+                    position.amount - maxRefund - repayAmount,
                     position.underlying.decimals,
                     prices[position.underlying.address],
                   )}{' '}
@@ -195,7 +195,8 @@ const RepayModal = ({
         disabled={
           repayAmount === 0n ||
           (!isUseCollateral &&
-            repayAmount > balances[position.underlying.address])
+            repayAmount > balances[position.underlying.address]) ||
+          (!isUseCollateral && repayAmount > position.amount - maxRefund)
         }
         className="font-bold text-base sm:text-xl bg-green-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 h-12 sm:h-16 rounded-lg text-white disabled:text-gray-300 dark:disabled:text-gray-500"
         onClick={async () => {
@@ -229,6 +230,8 @@ const RepayModal = ({
           : !isUseCollateral &&
             repayAmount > balances[position.underlying.address]
           ? `Insufficient ${position.underlying.symbol} balance`
+          : !isUseCollateral && repayAmount > position.amount - maxRefund
+          ? `Cannot repay more than remaining debt`
           : isUseCollateral
           ? 'Repay with Collateral'
           : 'Repay'}

--- a/components/modal/repay-modal.tsx
+++ b/components/modal/repay-modal.tsx
@@ -10,6 +10,7 @@ import { fetchCallDataByOdos } from '../../apis/odos'
 import Modal from '../../components/modal/modal'
 import { Balances } from '../../model/balances'
 import { Prices } from '../../model/prices'
+import { min } from '../../utils/bigint'
 
 const RepayModal = ({
   onClose,
@@ -21,7 +22,6 @@ const RepayModal = ({
   setValue,
   prices,
   repayAmount,
-  available,
   balances,
   showSlippageSelect,
   slippage,
@@ -34,7 +34,6 @@ const RepayModal = ({
   repay,
   amount,
   refund,
-  minBalance,
 }: {
   onClose: () => void
   setShowSlippageSelect: React.Dispatch<React.SetStateAction<boolean>>
@@ -45,7 +44,6 @@ const RepayModal = ({
   setValue: (value: string) => void
   prices: Prices
   repayAmount: bigint
-  available: bigint
   balances: Balances
   showSlippageSelect: boolean
   slippage: string
@@ -68,7 +66,6 @@ const RepayModal = ({
   ) => Promise<void>
   amount: bigint
   refund: bigint
-  minBalance: bigint
 }) => {
   return (
     <Modal
@@ -127,7 +124,10 @@ const RepayModal = ({
               value={value}
               onValueChange={setValue}
               price={prices[position.underlying.address]}
-              balance={minBalance}
+              balance={min(
+                position.amount,
+                balances[position.underlying.address],
+              )}
             />
           </>
         )}
@@ -192,7 +192,6 @@ const RepayModal = ({
       <button
         disabled={
           repayAmount === 0n ||
-          repayAmount > available ||
           (!isUseCollateral &&
             repayAmount > balances[position.underlying.address])
         }
@@ -225,8 +224,6 @@ const RepayModal = ({
       >
         {repayAmount === 0n
           ? 'Enter amount to repay'
-          : repayAmount > available
-          ? 'Not enough coupons for sale'
           : !isUseCollateral &&
             repayAmount > balances[position.underlying.address]
           ? `Insufficient ${position.underlying.symbol} balance`

--- a/components/modal/withdraw-modal.tsx
+++ b/components/modal/withdraw-modal.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { formatUnits } from 'viem'
-import { min } from 'hardhat/internal/util/bigint'
 
 import { BondPosition } from '../../model/bond-position'
 import CurrencyAmountInput from '../../components/currency-amount-input'
 import Modal from '../../components/modal/modal'
 import { Currency } from '../../model/currency'
 import { Prices } from '../../model/prices'
+import { min } from '../../utils/bigint'
 
 const WithdrawModal = ({
   position,

--- a/containers/modal/repay-modal-container.tsx
+++ b/containers/modal/repay-modal-container.tsx
@@ -84,15 +84,15 @@ const RepayModalContainer = ({
   const { data } = useQuery(
     ['coupon-refundable-amount-to-repay', position, repayAmount],
     async () => {
-      const market = (await fetchMarkets())
+      const markets = (await fetchMarkets())
         .filter((market) =>
           isAddressEqual(
             market.quoteToken.address,
             position.substitute.address,
           ),
         )
-        .filter((market) => market.epoch === position.toEpoch.id)[0]
-      return calculateCouponsToRepay(position.substitute, market, repayAmount)
+        .filter((market) => market.epoch <= position.toEpoch.id)
+      return calculateCouponsToRepay(position.substitute, markets, repayAmount)
     },
     {
       keepPreviousData: true,

--- a/containers/modal/repay-modal-container.tsx
+++ b/containers/modal/repay-modal-container.tsx
@@ -7,7 +7,7 @@ import { useCurrencyContext } from '../../contexts/currency-context'
 import { dollarValue } from '../../utils/numbers'
 import { fetchMarkets } from '../../apis/market'
 import { calculateCouponsToRepay } from '../../model/market'
-import { max, min } from '../../utils/bigint'
+import { max } from '../../utils/bigint'
 import { useBorrowContext } from '../../contexts/borrow-context'
 import { fetchAmountOutByOdos } from '../../apis/odos'
 import RepayModal from '../../components/modal/repay-modal'
@@ -100,7 +100,6 @@ const RepayModalContainer = ({
   )
 
   const refund = useMemo(() => data?.refund ?? 0n, [data?.refund])
-  const available = useMemo(() => data?.available ?? 0n, [data?.available])
 
   const currentLtv = useMemo(
     () =>
@@ -155,7 +154,6 @@ const RepayModalContainer = ({
       setValue={setValue}
       prices={prices}
       repayAmount={repayAmount}
-      available={available}
       balances={balances}
       showSlippageSelect={showSlippageSelect}
       slippage={slippage}
@@ -168,11 +166,6 @@ const RepayModalContainer = ({
       repay={repay}
       amount={amount}
       refund={refund}
-      minBalance={min(
-        position.amount,
-        available,
-        balances[position.underlying.address],
-      )}
     />
   )
 }

--- a/containers/modal/repay-modal-container.tsx
+++ b/containers/modal/repay-modal-container.tsx
@@ -92,7 +92,12 @@ const RepayModalContainer = ({
           ),
         )
         .filter((market) => market.epoch <= position.toEpoch.id)
-      return calculateCouponsToRepay(position.substitute, markets, repayAmount)
+      return calculateCouponsToRepay(
+        position.substitute,
+        markets,
+        position.amount,
+        repayAmount,
+      )
     },
     {
       keepPreviousData: true,
@@ -100,6 +105,7 @@ const RepayModalContainer = ({
   )
 
   const refund = useMemo(() => data?.refund ?? 0n, [data?.refund])
+  const maxRefund = useMemo(() => data?.maxRefund ?? 0n, [data?.maxRefund])
 
   const currentLtv = useMemo(
     () =>
@@ -165,6 +171,7 @@ const RepayModalContainer = ({
       repayWithCollateral={repayWithCollateral}
       repay={repay}
       amount={amount}
+      maxRefund={maxRefund}
       refund={refund}
     />
   )

--- a/containers/modal/repay-modal-container.tsx
+++ b/containers/modal/repay-modal-container.tsx
@@ -127,7 +127,7 @@ const RepayModalContainer = ({
   )
 
   const expectedLtv = useMemo(() => {
-    const debtAmount = max(position.amount - repayAmount, 0n)
+    const debtAmount = max(position.amount - repayAmount - refund, 0n)
     const debtValue = dollarValue(
       debtAmount,
       position.underlying.decimals,
@@ -147,7 +147,7 @@ const RepayModalContainer = ({
       : collateralAmount === 0n
       ? '0'
       : debtValue.times(100).div(collateralValue).toFixed(2)
-  }, [repayAmount, isUseCollateral, amount, position, prices])
+  }, [repayAmount, refund, isUseCollateral, amount, position, prices])
 
   return (
     <RepayModal

--- a/contexts/borrow-context.tsx
+++ b/contexts/borrow-context.tsx
@@ -209,11 +209,8 @@ export const BorrowProvider = ({ children }: React.PropsWithChildren<{}>) => {
         return
       }
 
-      const minimumInterestEarned = min(
-        BigInt(
-          Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
-        ),
-        expectedProceeds,
+      const minimumInterestEarned = BigInt(
+        Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
       )
       const wethBalance = isEthereum(position.underlying)
         ? balances[position.underlying.address] - (balance?.value || 0n)
@@ -298,11 +295,8 @@ export const BorrowProvider = ({ children }: React.PropsWithChildren<{}>) => {
         return
       }
 
-      const minimumInterestEarned = min(
-        BigInt(
-          Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
-        ),
-        expectedProceeds,
+      const minimumInterestEarned = BigInt(
+        Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
       )
 
       try {
@@ -539,11 +533,8 @@ export const BorrowProvider = ({ children }: React.PropsWithChildren<{}>) => {
         return
       }
 
-      const minimumInterestEarned = min(
-        BigInt(
-          Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
-        ),
-        expectedProceeds,
+      const minimumInterestEarned = BigInt(
+        Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
       )
       try {
         const { deadline, s, r, v } = await permit721(

--- a/contexts/borrow-context.tsx
+++ b/contexts/borrow-context.tsx
@@ -257,7 +257,7 @@ export const BorrowProvider = ({ children }: React.PropsWithChildren<{}>) => {
           functionName: 'repay',
           args: [
             position.id,
-            amount,
+            amount + minimumInterestEarned,
             minimumInterestEarned,
             { ...positionPermitResult },
             { ...debtPermitResult },

--- a/contexts/borrow-context.tsx
+++ b/contexts/borrow-context.tsx
@@ -236,7 +236,7 @@ export const BorrowProvider = ({ children }: React.PropsWithChildren<{}>) => {
           position.underlying,
           walletClient.account.address,
           CONTRACT_ADDRESSES.BorrowController,
-          amount,
+          amount + minimumInterestEarned,
           deadline,
         )
 

--- a/contexts/deposit-context.tsx
+++ b/contexts/deposit-context.tsx
@@ -83,11 +83,8 @@ export const DepositProvider = ({ children }: React.PropsWithChildren<{}>) => {
         return
       }
 
-      const minimumInterestEarned = min(
-        BigInt(
-          Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
-        ),
-        expectedProceeds,
+      const minimumInterestEarned = BigInt(
+        Math.floor(Number(expectedProceeds) * (1 - SLIPPAGE_PERCENTAGE)),
       )
       const wethBalance = isEthereum(asset.underlying)
         ? balances[asset.underlying.address] - (balance?.value || 0n)

--- a/model/market.ts
+++ b/model/market.ts
@@ -439,6 +439,19 @@ export function calculateCouponsToWithdraw(
     new Error('Substitute token is not supported')
   }
 
+  const availableCoupons = min(
+    ...markets.map((market) => market.totalAsksInBaseAfterFees()),
+  )
+  const available = max(
+    availableCoupons -
+      markets.reduce(
+        (acc, market) =>
+          acc + market.take(substitute.address, availableCoupons).amountIn,
+        0n,
+      ),
+    0n,
+  )
+
   const maxRepurchaseFee = markets.reduce(
     (acc, market) =>
       acc + market.take(substitute.address, positionAmount).amountIn,
@@ -457,18 +470,6 @@ export function calculateCouponsToWithdraw(
     )
   }
 
-  const availableCoupons = min(
-    ...markets.map((market) => market.totalAsksInBaseAfterFees()),
-  )
-  const available = max(
-    availableCoupons -
-      markets.reduce(
-        (acc, market) =>
-          acc + market.take(substitute.address, availableCoupons).amountIn,
-        0n,
-      ),
-    0n,
-  )
   return {
     maxRepurchaseFee,
     repurchaseFee,

--- a/model/market.ts
+++ b/model/market.ts
@@ -528,8 +528,10 @@ export function calculateCouponsToBorrow(
 export function calculateCouponsToRepay(
   substitute: Currency,
   markets: Market[],
+  positionAmount: bigint,
   repayAmount: bigint,
 ): {
+  maxRefund: bigint
   refund: bigint
 } {
   if (
@@ -545,6 +547,11 @@ export function calculateCouponsToRepay(
   }
 
   return {
+    maxRefund: markets.reduce(
+      (acc, market) =>
+        acc + market.spend(market.baseToken.address, positionAmount).amountOut,
+      0n,
+    ),
     refund: markets.reduce(
       (acc, market) =>
         acc + market.spend(market.baseToken.address, repayAmount).amountOut,

--- a/model/market.ts
+++ b/model/market.ts
@@ -306,15 +306,10 @@ export const calculateTotalDeposit = (
   initialDeposit: bigint,
 ): {
   totalDeposit: bigint
-  available: bigint
 } => {
   let totalDeposit = initialDeposit
   const amountOuts = [...Array(markets.length).keys()].map(
     () => 2n ** 256n - 1n,
-  )
-
-  const available = min(
-    ...markets.map((market) => market.totalBidsInBaseAfterFees()),
   )
 
   while (amountOuts.reduce((a, b) => a + b, 0n) > 0n) {
@@ -328,7 +323,7 @@ export const calculateTotalDeposit = (
     totalDeposit = totalDeposit + initialDeposit
   }
 
-  return { totalDeposit, available }
+  return { totalDeposit }
 }
 
 export const calculateDepositApy = (
@@ -339,7 +334,6 @@ export const calculateDepositApy = (
 ): {
   proceeds: bigint
   apy: number
-  available: bigint
 } => {
   if (
     markets.some(
@@ -354,10 +348,7 @@ export const calculateDepositApy = (
   }
 
   const endTimestamp = Math.max(...markets.map((market) => market.endTimestamp))
-  const { totalDeposit, available } = calculateTotalDeposit(
-    markets,
-    initialDeposit,
-  )
+  const { totalDeposit } = calculateTotalDeposit(markets, initialDeposit)
   const p =
     (Number(totalDeposit) - Number(initialDeposit)) / Number(initialDeposit)
   const d = Number(endTimestamp) - currentTimestamp
@@ -366,7 +357,6 @@ export const calculateDepositApy = (
   return {
     apy,
     proceeds: totalDeposit - initialDeposit,
-    available,
   }
 }
 

--- a/model/market.ts
+++ b/model/market.ts
@@ -537,23 +537,28 @@ export function calculateCouponsToBorrow(
 
 export function calculateCouponsToRepay(
   substitute: Currency,
-  market: Market,
+  markets: Market[],
   repayAmount: bigint,
 ): {
   refund: bigint
-  available: bigint
 } {
   if (
-    !isAddressEqual(
-      market.quoteToken.address,
-      substitute.address as `0x${string}`,
+    markets.some(
+      (market) =>
+        !isAddressEqual(
+          market.quoteToken.address,
+          substitute.address as `0x${string}`,
+        ),
     )
   ) {
     new Error('Substitute token is not supported')
   }
 
   return {
-    refund: market.spend(market.baseToken.address, repayAmount).amountOut,
-    available: market.totalBidsInBaseAfterFees(),
+    refund: markets.reduce(
+      (acc, market) =>
+        acc + market.spend(market.baseToken.address, repayAmount).amountOut,
+      0n,
+    ),
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "rm -rf node_modules/.cache && storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "dependencies": {
@@ -60,5 +60,13 @@
     "tailwindcss": "^3.3.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.0.4"
+  },
+  "browserslist": {
+    "development": [
+      "last 2 chrome version",
+      "last 2 firefox version",
+      "last 2 safari version",
+      "last 2 edge version"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,13 +60,5 @@
     "tailwindcss": "^3.3.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.0.4"
-  },
-  "browserslist": {
-    "development": [
-      "last 2 chrome version",
-      "last 2 firefox version",
-      "last 2 safari version",
-      "last 2 edge version"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "storybook": "rm -rf node_modules/.cache && storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "dependencies": {

--- a/pages/borrow/[symbol].tsx
+++ b/pages/borrow/[symbol].tsx
@@ -132,7 +132,7 @@ const Borrow = () => {
     return interestsByEpochsBorrowed[epochs - 1]?.maxInterest ?? 0n
   }, [epochs, interestsByEpochsBorrowed])
 
-  const maxLoanAmount = useMemo(() => {
+  const maxLoanableAmount = useMemo(() => {
     if (
       epochs === 0 ||
       !interestsByEpochsBorrowed ||
@@ -259,7 +259,7 @@ const Borrow = () => {
                       value={loanValue}
                       onValueChange={setLoanValue}
                       price={prices[asset.underlying.address]}
-                      balance={min(maxLoanAmount, available)}
+                      balance={min(maxLoanableAmount, available)}
                     />
                   </div>
                   <div className="flex flex-col gap-4">

--- a/pages/borrow/[symbol].tsx
+++ b/pages/borrow/[symbol].tsx
@@ -259,7 +259,7 @@ const Borrow = () => {
                       value={loanValue}
                       onValueChange={setLoanValue}
                       price={prices[asset.underlying.address]}
-                      balance={min(maxLoanableAmount, available)}
+                      balance={min(maxLoanableAmount - maxInterest, available)}
                     />
                   </div>
                   <div className="flex flex-col gap-4">

--- a/pages/borrow/[symbol].tsx
+++ b/pages/borrow/[symbol].tsx
@@ -259,7 +259,7 @@ const Borrow = () => {
                       value={loanValue}
                       onValueChange={setLoanValue}
                       price={prices[asset.underlying.address]}
-                      balance={maxLoanAmount}
+                      balance={min(maxLoanAmount, available)}
                     />
                   </div>
                   <div className="flex flex-col gap-4">

--- a/pages/deposit/[symbol].tsx
+++ b/pages/deposit/[symbol].tsx
@@ -69,13 +69,6 @@ const Deposit = () => {
     return proceedsByEpochsDeposited[epochs - 1]?.proceeds ?? 0n
   }, [proceedsByEpochsDeposited, epochs])
 
-  const available = useMemo(() => {
-    if (epochs === 0 || !proceedsByEpochsDeposited) {
-      return 0n
-    }
-    return proceedsByEpochsDeposited[epochs - 1]?.available ?? 0n
-  }, [proceedsByEpochsDeposited, epochs])
-
   return (
     <div className="flex flex-1">
       <Head>
@@ -204,12 +197,7 @@ const Deposit = () => {
                   </div>
                 </div>
                 <button
-                  disabled={
-                    amount === 0n ||
-                    epochs === 0 ||
-                    amount > balance ||
-                    amount > available
-                  }
+                  disabled={amount === 0n || epochs === 0 || amount > balance}
                   className="font-bold text-base sm:text-xl bg-green-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 h-12 sm:h-16 rounded-lg text-white disabled:text-gray-300 dark:disabled:text-gray-500"
                   onClick={async () => {
                     const hash = await deposit(
@@ -225,8 +213,6 @@ const Deposit = () => {
                 >
                   {amount > balance
                     ? `Insufficient ${asset.underlying.symbol} balance`
-                    : amount > available
-                    ? 'Not enough coupons for sale'
                     : 'Confirm'}
                 </button>
               </div>

--- a/utils/bigint.ts
+++ b/utils/bigint.ts
@@ -1,3 +1,3 @@
-export const LIQUIDATION_TARGET_LTV_PRECISION = 10n ** 6n
+export const LIQUIDATION_TARGET_LTV_PRECISION = 1000000n
 export const max = (...args: bigint[]) => args.reduce((m, e) => (e > m ? e : m))
 export const min = (...args: bigint[]) => args.reduce((m, e) => (e < m ? e : m))


### PR DESCRIPTION
- Removed calculation for `available` in the `deposit` and `repay` functions.
- Fixed storybooks to use `utils/min`.
- Corrected the `repay` logic.